### PR TITLE
fix: length input validation for message

### DIFF
--- a/components/form/helpers/fieldError.js
+++ b/components/form/helpers/fieldError.js
@@ -21,9 +21,12 @@ export default class FieldError {
         return this;
     }
 
-    isLength(options) {
-        if (!validator.isLength(this.value, options)) {
+    isLength({ min, max }) {
+        if (!validator.isLength(this.value, { min })) {
             this.errors.push("Is too short");
+        }
+        if (!validator.isLength(this.value, { max })) {
+            this.errors.push("Is too long");
         }
 
         return this;


### PR DESCRIPTION
correctly set separate error messages for minimum and maximum length

I was applying for mentor but form gave error saying my text was too short, which wasn't the case.
meanwhile i directly dropped an email as i couldn't submit the form.